### PR TITLE
Maintenance changes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,18 +8,20 @@ You must set up your app’s associated domains. To learn how to set up your app
 
 ## How to use
 ```ts
-import { Plugins } from '@capacitor/core';
-const { SavePassword } = Plugins;
+import { Capacitor } from '@capacitor/core';
+import { SavePassword } from 'capacitor-ios-autofill-save-password';
     
-login (username, password) {
+login(username: string, password: string) {
     // your login logic here
         
     // call the plugin if login is successful on iOS
-    if (this.platform.is('ios')) {
+    if (Capacitor.getPlatform() === 'ios') {
         SavePassword.promptDialog({
-        username: username,
-        password: password
-        });
+            username: username,
+            password: password,
+        })
+        .then(() => console.log('promptDialog success'))
+        .catch((err) => console.error('promptDialog failure', err));
     }
 }
 ```

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -6,10 +6,10 @@ import UIKit
 public class SavePassword: CAPPlugin {
 
     @objc func promptDialog(_ call: CAPPluginCall) {
-        let loginScreen = LoginScreenViewController()
-        loginScreen.usernameTextField.text = call.getString("username") ?? ""
-        loginScreen.passwordTextField.text = call.getString("password") ?? ""
         DispatchQueue.main.async {
+            let loginScreen = LoginScreenViewController()
+            loginScreen.usernameTextField.text = call.getString("username") ?? ""
+            loginScreen.passwordTextField.text = call.getString("password") ?? ""
             self.bridge?.webView?.addSubview(loginScreen.view)
             loginScreen.view.removeFromSuperview()
         }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -10,7 +10,7 @@ public class SavePassword: CAPPlugin {
         loginScreen.usernameTextField.text = call.getString("username") ?? ""
         loginScreen.passwordTextField.text = call.getString("password") ?? ""
         DispatchQueue.main.async {
-            self.bridge?.getWebView()?.addSubview(loginScreen.view)
+            self.bridge?.webView?.addSubview(loginScreen.view)
             loginScreen.view.removeFromSuperview()
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-ios-autofill-save-password",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Prompt to display dialog for saving password to keychain for iOS webview app.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
1. Replaces deprecated `getWebView()` with `webView`
<img width="413" alt="Screenshot 2022-06-15 at 13 52 56" src="https://user-images.githubusercontent.com/1189149/173841018-7b764643-22bf-46f4-ab49-6420c7e9bb30.png">

2. Fixes runtime issues (UI APIs must be used from main thread only)
<img width="672" alt="Screenshot 2022-06-15 at 14 00 33" src="https://user-images.githubusercontent.com/1189149/173841078-436bc5e8-163b-4101-9c98-7f95a230d1ff.png">

3. Updates "How to use" example with Capacitor v3 syntax
4. Bumps version to `1.1.3`