### PR TITLE
Compatibility with Capacitor 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "author": "Cuong Phan",
   "license": "MIT",
   "devDependencies": {
-    "@capacitor/core": "^5.0.0",
-    "@capacitor/ios": "^5.0.0",
+    "@capacitor/core": "^6.0.0",
+    "@capacitor/ios": "^6.0.0",
     "@ionic/swiftlint-config": "^1.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "rimraf": "^3.0.2",
@@ -26,7 +26,7 @@
     "typescript": "^4.1.0"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/core": "^6.0.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
do capacitor 6 plugin migration steps described according to:
 https://capacitorjs.com/docs/updating/plugins/6-0