### PR TITLE
Update for future capacitor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.1.0"
   },
   "peerDependencies": {
-    "@capacitor/core": "^6.0.0"
+    "@capacitor/core": ">=6.0.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
I updated package.json to support Capacitor v6 and all future versions (including current v7).
This should reduce maintenance and save update time.